### PR TITLE
Implement run_auto for selected targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Version 0.3.2
+
+* Add support for running only some tasks in auto_run
+* Implemented `TaskManager.inputs` to get the inputs for
+  a given list of targets.
+* Implemented `TaskManager.stop_watch` and watcher cleanup
+* Uncommented skipping run if queued changes are empty in `auto_run`
+* Added support for calling `watch` only for the dependencies of
+  specific targets
+
 ## Version 0.3.1
 
 * Added auto_run / auto_stop that control a "watchdog" fiber that

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 * Uncommented skipping run if queued changes are empty in `auto_run`
 * Added support for calling `watch` only for the dependencies of
   specific targets
+* Simpler one-watcher implementation of watch
+* Only react to specific Inotify flags in watch
 
 ## Version 0.3.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: croupier
-version: 0.3.1
+version: 0.3.2
 description: A smart task definition and execution library
 authors:
   - Roberto Alsina <roberto.alsina@gmail.com>

--- a/spec/croupier_spec.cr
+++ b/spec/croupier_spec.cr
@@ -703,8 +703,20 @@ describe "TaskManager" do
         Fiber.yield
         TaskManager.@queued_changes.should eq Set{"input"}
         File.open("input2", "w") << "foo"
-        Fiber.yield
+        sleep 0.1.seconds # FIXME: this should work with a yield
         TaskManager.@queued_changes.should eq Set{"input", "input2"}
+      end
+    end
+  end
+
+  describe "inputs" do
+    it "should list all inputs, including transitive dependencies" do
+      with_scenario("basic") do
+        TaskManager.inputs(["output1"]).empty?.should be_true
+        TaskManager.inputs(["output3"]).should eq Set{"input"}
+        TaskManager.inputs(["output4"]).should eq Set{"input", "output3"}
+        TaskManager.inputs(["output5"]).should eq Set{"input2"}
+        TaskManager.inputs(["output4", "output5"]).should eq Set{"input", "input2", "output3"}
       end
     end
   end
@@ -799,6 +811,39 @@ describe "TaskManager" do
         expect_raises(Exception, "No inputs to watch") do
           TaskManager.auto_run
         end
+      end
+    end
+
+    it "should only run the specified targets" do
+      with_scenario("basic") do
+        TaskManager.auto_run(targets: ["output3"])
+        # At this point output1/3 doesn't exist
+        File.exists?("output1").should be_false
+        File.exists?("output3").should be_false
+
+        # This triggers building output3
+        File.open("input", "w") << "bar"
+        Fiber.yield
+        TaskManager.auto_stop
+        # At this point output3 exists, output1 doesn't
+        File.exists?("output1").should be_false
+        File.exists?("output3").should be_true
+      end
+    end
+
+    it "should not be triggered by deps for not specified targets" do
+      with_scenario("basic") do
+        TaskManager.auto_run(targets: ["output5"])
+        # At this point output5 doesn't exist
+        File.exists?("output5").should be_false
+        File.exists?("output3").should be_false
+        # This triggers output3, which is not requested
+        File.open("input", "w") << "bar"
+        Fiber.yield
+        TaskManager.auto_stop
+        # No outputs created
+        File.exists?("output5").should be_false
+        File.exists?("output3").should be_false
       end
     end
   end

--- a/spec/croupier_spec.cr
+++ b/spec/croupier_spec.cr
@@ -834,6 +834,7 @@ describe "TaskManager" do
     it "should not be triggered by deps for not specified targets" do
       with_scenario("basic") do
         TaskManager.auto_run(targets: ["output5"])
+        sleep 0.2.seconds
         # At this point output5 doesn't exist
         File.exists?("output5").should be_false
         File.exists?("output3").should be_false


### PR DESCRIPTION
* Add support for running only some tasks in auto_run
* Implemented `TaskManager.inputs` to get the inputs for
  a given list of targets.
* Implemented `TaskManager.stop_watch` and watcher cleanup
* Uncommented skipping run if queued changes are empty in `auto_run`
* Added support for calling `watch` only for the dependencies of
  specific targets
* Simpler one-watcher implementation of watch
* Only react to specific Inotify flags in watch
