### PR TITLE
Fix tasks run once in auto

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Fixed bug saving .croupier, was missing all inputs
 * Added tests for `TaskManager.save_run`
 * Fixed bug in inotify watcher path lookup
+* Fixed bug where auto_run would only run tasks once
 
 ## Version 0.3.3
 


### PR DESCRIPTION
Found implementing auto mode in Hacé:

Tasks were only being triggered once, any further changes to inputs did not trigger them.