### PR TITLE
Implement fast_mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 * Implement k/v data as input/output for tasks
 * Implement *persistent* k/v store
+* Implement `fast_mode` for TaskManager, where it checks file
+  timestamps instead of contents to decide if they should
+  trigger tasks.
 
 ## Version 0.3.4
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,8 @@
 * Use state machines for tasks (see veelenga/aasm.cr)
 * Add directory dependencies (depend on all files in the tree)
 * Add wildcard dependencies (depend on all files / tasks matching a pattern)
-* Add a faster stale input check using file dates instead of hashes (like make)
 
+* ~~Add a faster stale input check using file dates instead of hashes (like make)~~
 * ~~Support a persistant k/v store~~
 * ~~Once it works fine with files, generalize to a k/v store using [kiwi](https://github.com/crystal-community/kiwi)~~
 * ~~Decide what to do in auto_run when no task has inputs~~


### PR DESCRIPTION
Add a `fast_mode` flag for `TaskManager` which uses file timestamps instead of file contents
to decide whether the file has been modified.

While this is less accurate and may trigger unnecessary jobs, it *may* be faster in some circumstances,
and is Make's default behaviour.