### PR TITLE
Fix running unready tasks

### DIFF
--- a/spec/croupier_spec.cr
+++ b/spec/croupier_spec.cr
@@ -550,6 +550,16 @@ describe "TaskManager" do
         end
       end
 
+      it "should fail if the next task to run is not ready" do
+        with_scenario("empty") do
+          Task.new(output: "t1", inputs: ["kv://foo"], proc: TaskProc.new { "" })
+          expect_raises(Exception) do
+            TaskManager.tasks["t1"].ready?.should be_false
+            TaskManager.run_tasks
+          end
+        end
+      end
+
       it "should run no tasks when dry_run is true" do
         with_scenario("basic", to_create: {"input" => "foo", "input2" => "bar"}) do
           TaskManager.run_tasks(parallel: parallel, run_all: true, dry_run: true)

--- a/spec/croupier_spec.cr
+++ b/spec/croupier_spec.cr
@@ -1069,7 +1069,8 @@ describe "TaskManager" do
       with_scenario("empty") do
         x = 0
         TaskManager.set("foo", "bar1")
-        Task.new(inputs: ["kv://foo"], output: "kv://bar", proc: TaskProc.new { (x = x + 1).to_s })
+        Task.new(inputs: ["kv://foo"], output: "kv://bar",
+          proc: TaskProc.new { (x = x + 1).to_s })
         TaskManager.auto_run
         x.should eq 0
         TaskManager.set("foo", "bar2")

--- a/spec/croupier_spec.cr
+++ b/spec/croupier_spec.cr
@@ -452,6 +452,15 @@ describe "Task" do
     end
   end
 
+  describe "waiting_for" do
+    it "should say a task is waiting if a dependency that doesn't exist" do
+      with_scenario("basic") do
+        t = TaskManager.tasks["output4"]
+        t.waiting_for.should eq ["output3"]
+      end
+    end
+  end
+
   describe "ready?" do
     it "should consider all tasks without task dependencies as ready" do
       with_scenario("basic", to_create: {"input" => "foo", "input2" => "bar"}) do

--- a/src/croupier.cr
+++ b/src/croupier.cr
@@ -540,7 +540,7 @@ module Croupier
         next if t.nil? || finished.includes?(t)
         next unless run_all || t.stale? || t.@always_run
         Log.debug { "Running task for #{output}" }
-        raise "Can't run task for #{output}: Waiting for #{t.waiting_for}" unless t.ready?
+        raise "Can't run task for #{output}: Waiting for #{t.waiting_for}" unless t.ready? || dry_run
         begin
           t.run unless dry_run
         rescue ex

--- a/src/croupier.cr
+++ b/src/croupier.cr
@@ -220,13 +220,17 @@ module Croupier
     # If any inputs don't fit those criteria, they are being
     # waited for.
     def waiting_for
-      @inputs.reject { |input|
+      @inputs.reject do |input|
         if TaskManager.tasks.has_key? input
           !TaskManager.tasks[input].stale?
         else
-          File.exists? input
+          if input.lchop? "kv://"
+            !TaskManager.@_store.get(input.lchop("kv://")).nil?
+          else
+            File.exists? input
+          end
         end
-      }
+      end
     end
 
     # A task is ready if it is stale and not waiting for anything

--- a/src/croupier.cr
+++ b/src/croupier.cr
@@ -540,6 +540,7 @@ module Croupier
         next if t.nil? || finished.includes?(t)
         next unless run_all || t.stale? || t.@always_run
         Log.debug { "Running task for #{output}" }
+        raise "Can't run task for #{output}: Waiting for #{t.waiting_for}" unless t.ready?
         begin
           t.run unless dry_run
         rescue ex
@@ -581,6 +582,9 @@ module Croupier
         # task graph because of multiple outputs. We don't
         # want to run it twice.
         batch = stale_tasks.select(&.ready?).uniq!
+
+        # FIXME: should error out if there are no ready tasks
+
         batch.each do |t|
           spawn do
             begin


### PR DESCRIPTION
Croupier was not complaining when running "unready" tasks. Those are tasks which require inputs that are not available.

In serial mode this would usually be ok, because if the input was really not ready the task would error out.

In parallel mode, however, this caused a lockup because no tasks were queued, since they were all stale but not ready.
